### PR TITLE
Add permission 'pull-request: write' for dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
     if: github.actor == 'dependabot[bot]' && github.event_name == 'pull_request'
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - name: 'Merge (if dependabot)'
       uses: fastify/github-action-merge-dependabot@v1


### PR DESCRIPTION
See comment: https://github.com/actions/first-interaction/issues/10#issuecomment-1114048624

It seems like what I'm doing falls foul of Github's permission model.
