### PR TITLE
dependabot automerge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     - name: 'Merge (if dependabot)'
       uses: fastify/github-action-merge-dependabot@v1
       with:
-        github-token: ${{secrets.github_token}}
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
   bump-version:
     runs-on: ubuntu-latest
     name: Bump version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,6 @@ jobs:
     if: github.actor == 'dependabot[bot]' && github.event_name == 'pull_request'
     needs: test
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
     - name: 'Merge (if dependabot)'
       uses: fastify/github-action-merge-dependabot@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
     if: github.actor == 'dependabot[bot]' && github.event_name == 'pull_request'
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - name: 'Merge (if dependabot)'
       uses: fastify/github-action-merge-dependabot@v1


### PR DESCRIPTION
- Add permission 'pull-request: write' for dependabot
- Revert "Add permission 'pull-request: write' for dependabot (#34)"
- Provide GITHUB_TOKEN named correctly
